### PR TITLE
fix: registering VoIP token when auto login process

### DIFF
--- a/QuickStart/AppDelegate+VoIPPush.swift
+++ b/QuickStart/AppDelegate+VoIPPush.swift
@@ -24,8 +24,20 @@ extension AppDelegate: PKPushRegistryDelegate {
         UserDefaults.standard.voipPushToken = pushCredentials.token
         print("Push token is \(pushCredentials.token.toHexString())")
         
-        SendBirdCall.registerVoIPPush(token: pushCredentials.token, unique: true) { error in
-            guard error == nil else { return }
+        guard SendBirdCall.currentUser != nil else {
+            print("No logged in user.")
+            return
+        }
+        self.registerVoIPPushToken(token: pushCredentials.token)
+    }
+    
+    func registerVoIPPushToken(token: Data) {
+        SendBirdCall.registerVoIPPush(token: token, unique: true) { error in
+            if let error {
+                print("Error registering VoIP push token: \(error.localizedDescription)")
+                return
+            }
+            print("Successfully registered VoIP push token.")
         }
     }
     

--- a/QuickStart/AppDelegate.swift
+++ b/QuickStart/AppDelegate.swift
@@ -32,8 +32,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // SendBirdCall.configure(appId: appId)
         // UserDefaults.standard.designatedAppId = appId
 
-        self.autoSignIn { error in
-            if error == nil { return }
+        self.autoSignIn { [weak self] error in
+            guard let self else { return }
+            if error == nil {
+                if let token = UserDefaults.standard.voipPushToken {
+                    self.registerVoIPPushToken(token: token)
+                }
+                return
+            }
             // Show SignIn controller when failed to auto sign in
             self.window?.rootViewController?.present(UIStoryboard.signController(), animated: true, completion: nil)
         }


### PR DESCRIPTION
로드인된 상태에서 앱을 재실행할 때, `currentUser` 가 없으면 `SendBirdCall.registerVoIPPushToken` 가 실패합니다. 그래서 푸시를 받지 못하게 되더라구요.

`AppDelegate::autoSignIn` 실행 후 VoIP 토큰을 등록하도록 수정해 봅니다.